### PR TITLE
Docker Image: Inject git commit ID during build for better traceability

### DIFF
--- a/.github/workflows/deploy_development.yml
+++ b/.github/workflows/deploy_development.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Build + Push image ("development")
         run: |
           docker buildx build \
+            --build-arg GIT_COMMIT="${{github.sha}}" \
             --platform "linux/arm/v7,linux/arm64" \
             --tag "${{secrets.REGISTRY_USERNAME}}/nexus3:development" \
             --output "type=image,push=true" \

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Build + Push image (tag = git release tag)
         run: |
           docker buildx build \
+            --build-arg GIT_COMMIT="${{github.sha}}" \
             --platform "linux/arm/v7,linux/arm64" \
             --tag "${{secrets.REGISTRY_USERNAME}}/nexus3:${GITHUB_REF#refs/tags/}" \
             --output "type=image,push=true" \
@@ -41,6 +42,7 @@ jobs:
       - name: Build + Push image ("latest")
         run: |
           docker buildx build \
+            --build-arg GIT_COMMIT="${{github.sha}}" \
             --platform "linux/arm/v7,linux/arm64" \
             --tag "${{secrets.REGISTRY_USERNAME}}/nexus3:latest" \
             --output "type=image,push=true" \

--- a/.github/workflows/validate_pull_request.yml
+++ b/.github/workflows/validate_pull_request.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Build image (no push)
         run: |
           docker buildx build \
+            --build-arg GIT_COMMIT="${{github.sha}}" \
             --platform "linux/arm/v7,linux/arm64" \
             --output "type=image,push=false" \
             --file ./Dockerfile .

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,11 @@ RUN mkdir /tmp/sonatype && \
 # https://github.com/sonatype/docker-nexus3/blob/master/Dockerfile
 FROM ubuntu:focal-20200115
 
+# Image metadata
+# git commit
+ARG GIT_COMMIT=unspecified
+LABEL org.opencontainers.image.revision=${GIT_COMMIT}
+
 # Install Java 8 and wget
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update && \


### PR DESCRIPTION
For better traceability between deployment and code, we inject commit ID during build.

Commit ID is stored as label 'org.opencontainers.image.revision', and injected during GitHub workflow build via '--build-arg GIT_COMMIT=...'.