### PR TITLE
Upgrade to 3.33.0, use Debian as base, reduce download over multiple builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Download, extract Nexus to /tmp/sonatype/nexus
 FROM ubuntu:latest as downloader
 
-ARG NEXUS_VERSION=3.32.0-03
+ARG NEXUS_VERSION=3.33.0-01
 ARG NEXUS_DOWNLOAD_URL=https://download.sonatype.com/nexus/3/nexus-${NEXUS_VERSION}-unix.tar.gz
 
 ADD "${NEXUS_DOWNLOAD_URL}" "/tmp/nexus.tar.gz"


### PR DESCRIPTION
Changes:
- Update to latest Nexus version
- Use `debian:buster-slim` as base (closes #12)
- Reduce data downloaded during build (closes #11)

Credit to mhkarimi1383 for the ideas and sample code in #10 (resolves #10 once merged).